### PR TITLE
Disable the brp-python-hardlink rpm macro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,10 @@ ADD container/UnlimitedJCEPolicyJDK7.zip /tmp/
 RUN unzip -o -j -q /tmp/UnlimitedJCEPolicyJDK7.zip -d $JAVA_HOME/jre/lib/security/
 RUN rm -rf /tmp/UnlimitedJCEPolicyJDK7.zip
 
+# Comment out  '/usr/lib/rpm/redhat/brp-python-hardlink' in '/usr/lib/rpm/redhat/macros'
+RUN sed -i -- 's/\/usr\/lib\/rpm\/redhat\/brp-python-hardlink/# \/usr\/lib\/rpm\/redhat\/brp-python-hardlink/g' /usr/lib/rpm/redhat/macros
+
+
 # Install consul
 RUN wget -O /tmp/conzul.zip https://releases.hashicorp.com/consul/0.6.0/consul_0.6.0_linux_amd64.zip
 RUN unzip -o -j -q /tmp/conzul.zip -d /bin

--- a/setup.sh
+++ b/setup.sh
@@ -126,7 +126,7 @@ build-rpm(){
       --rm \
       --privileged \
       --entrypoint=/bin/bash \
-      -v $DEV_AMBARI_PROJECT_DIR/:/ambari:rw \
+      -v $DEV_AMBARI_PROJECT_DIR/:/ambari \
       -v $HOME/.m2/:/root/.m2 \
       -w $container_workspace \
       $DEV_DOCKER_IMAGE \


### PR DESCRIPTION
Disable the the brp-python-hardlink rpm macro as this macro creates hard links to compiled python scripts within the generated rpm. The rpm build is running inside VirtualBox shared folder in our dev env. VirtualBox does not support hard links within shared folders thus the rpm build is failing.
